### PR TITLE
Resolve parameters from constructor

### DIFF
--- a/src/Container/ParamResolver.php
+++ b/src/Container/ParamResolver.php
@@ -58,10 +58,7 @@ class ParamResolver
     public function fromConstructor(string $class, array $additional = []): array
     {
         if (\method_exists($class, '__construct')) {
-            $reflection = new \ReflectionClass($class);
-            $instance = $reflection->newInstanceWithoutConstructor();
-
-            return $this->fromCallable([$instance, '__construct'], $additional);
+            return $this->resolve((new \ReflectionClass($class))->getMethod('__construct'), $additional);
         }
 
         $parent = \get_parent_class($class);

--- a/src/Container/ParamResolver.php
+++ b/src/Container/ParamResolver.php
@@ -58,7 +58,10 @@ class ParamResolver
     public function fromConstructor(string $class, array $additional = []): array
     {
         if (\method_exists($class, '__construct')) {
-            return $this->fromCallable([$class, '__construct'], $additional);
+            $reflection = new \ReflectionClass($class);
+            $instance = $reflection->newInstanceWithoutConstructor();
+
+            return $this->fromCallable([$instance, '__construct'], $additional);
         }
 
         $parent = \get_parent_class($class);


### PR DESCRIPTION
I try to inject dependencies by constructor and got fatal exception:
```
FatalThrowableErrorNon-static method AppBundle\Service\AuthApi::__construct() cannot be called statically
--
some stacktrace:

in ParamResolver.php (line 48)
at ParamResolver->fromCallable(array('AppBundle\\Service\\AuthApi', '__construct'), array()) in ParamResolver.php (line 61)
at ParamResolver->fromConstructor('AppBundle\\Service\\AuthApi', array()) in Container.php (line 209)
at Container->Railt\Container\{closure}()in Container.php (line 192)