### PR TITLE
Exception serialize with debug information

### DIFF
--- a/src/Http/ErrorFormatter.php
+++ b/src/Http/ErrorFormatter.php
@@ -58,13 +58,15 @@ class ErrorFormatter implements Arrayable
         $exception = $this->exception;
         $result    = $this->renderItem($exception);
 
-        while ($exception->getPrevious()) {
-            if (! \array_key_exists('previous', $result)) {
-                $result['previous'] = [];
-            }
+        if ($this->debug) {
+            while ($exception->getPrevious()) {
+                if (! \array_key_exists('previous', $result)) {
+                    $result['previous'] = [];
+                }
 
-            $result['previous'][] = $this->renderItem($exception);
-            $exception            = $exception->getPrevious();
+                $result['previous'][] = $this->renderItem($exception);
+                $exception            = $exception->getPrevious();
+            }
         }
 
         return $result;
@@ -97,6 +99,7 @@ class ErrorFormatter implements Arrayable
             $result['trace'] = $e instanceof SchemaException
                 ? $e->getCompilerTrace()
                 : $e->getTraceAsString();
+            $result['previous'] = $this->renderItem($e->getPrevious());
         }
 
         return $result;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -164,11 +164,11 @@ class Response implements ResponseInterface
             case $error instanceof Arrayable:
                 return $error->toArray();
 
-            case $error instanceof \JsonSerializable:
-                return $error->jsonSerialize();
-
             case $error instanceof \Throwable:
                 return ErrorFormatter::render($error, $debug);
+
+            case $error instanceof \JsonSerializable:
+                return $error->jsonSerialize();
         }
 
         return (array)$error;


### PR DESCRIPTION
Webonyx return exception class that implements from `JsonSerializable` and `ErrorFormatter` just call `jsonSerialize()`. Webonyx error exception serialize debug fields, such as: `locations` and `path`. We have to override this logic by own.