### PR TITLE
Remove previous recursive exception generation

### DIFF
--- a/src/Http/ErrorFormatter.php
+++ b/src/Http/ErrorFormatter.php
@@ -99,7 +99,6 @@ class ErrorFormatter implements Arrayable
             $result['trace'] = $e instanceof SchemaException
                 ? $e->getCompilerTrace()
                 : $e->getTraceAsString();
-            $result['previous'] = $this->renderItem($e->getPrevious());
         }
 
         return $result;


### PR DESCRIPTION
I made mistake in last PR (forgot to remove recursive previous exception debug info). Also, sometimes previous exception may not exists and we will get error