### PR TITLE
Allow to get errors array that contains original exceptions

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -154,6 +154,14 @@ class Response implements ResponseInterface
     }
 
     /**
+     * @return array
+     */
+    public function getNativeErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
      * @param mixed $error
      * @param bool $debug
      * @return array

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -35,6 +35,11 @@ interface ResponseInterface extends Arrayable, Renderable
     public function getErrors(): array;
 
     /**
+     * @return array[]
+     */
+    public function getNativeErrors(): array;
+
+    /**
      * @return void
      */
     public function send(): void;


### PR DESCRIPTION
Response have to allow to get native errors without formatting their into serializable types