### PR TITLE
Fix class names in PHPDoc comments

### DIFF
--- a/src/Adapters/Webonyx/WebonyxInput.php
+++ b/src/Adapters/Webonyx/WebonyxInput.php
@@ -59,7 +59,7 @@ class WebonyxInput implements InputInterface
     private $dispatcher;
 
     /**
-     * Input constructor.
+     * WebonyxInput constructor.
      * @param Dispatcher $dispatcher
      * @param FieldDefinition $field
      * @param ResolveInfo $info

--- a/src/Foundation/Events/BaseFieldResolver.php
+++ b/src/Foundation/Events/BaseFieldResolver.php
@@ -23,7 +23,7 @@ abstract class BaseFieldResolver extends Event
     private $input;
 
     /**
-     * FieldResolved constructor.
+     * BaseFieldResolver constructor.
      * @param InputInterface $input
      */
     public function __construct(InputInterface $input)

--- a/src/Foundation/Extensions/BaseExtension.php
+++ b/src/Foundation/Extensions/BaseExtension.php
@@ -14,7 +14,7 @@ use Railt\Http\RequestInterface;
 use Railt\Http\ResponseInterface;
 
 /**
- * Class BaseServiceProvider
+ * Class BaseExtension
  */
 abstract class BaseExtension implements Extension
 {
@@ -24,7 +24,7 @@ abstract class BaseExtension implements Extension
     private $container;
 
     /**
-     * BaseServiceProvider constructor.
+     * BaseExtension constructor.
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)

--- a/src/Foundation/Extensions/Repository.php
+++ b/src/Foundation/Extensions/Repository.php
@@ -34,7 +34,7 @@ class Repository
     private $booted = false;
 
     /**
-     * Pipeline constructor.
+     * Repository constructor.
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)

--- a/src/Routing/Route/Directive.php
+++ b/src/Routing/Route/Directive.php
@@ -23,7 +23,7 @@ use Railt\Routing\Route;
 class Directive extends Route
 {
     /**
-     * DirectiveRoute constructor.
+     * Directive constructor.
      * @param ContainerInterface $container
      * @param DirectiveInvocation $directive
      * @param ClassLoader $loader

--- a/src/Routing/Store/BaseBox.php
+++ b/src/Routing/Store/BaseBox.php
@@ -25,7 +25,7 @@ abstract class BaseBox implements Box
     protected $serialized;
 
     /**
-     * Box constructor.
+     * BaseBox constructor.
      * @param mixed $data
      * @param mixed $serialized
      */

--- a/src/Routing/Store/ObjectBox.php
+++ b/src/Routing/Store/ObjectBox.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace Railt\Routing\Store;
 
 /**
- * Class Box
+ * Class ObjectBox
  */
 final class ObjectBox extends BaseBox implements \ArrayAccess
 {
     /**
-     * Box constructor.
+     * ObjectBox constructor.
      * @param mixed $data
      * @param array $serialized
      * @throws \LogicException

--- a/src/Routing/Store/ScalarBox.php
+++ b/src/Routing/Store/ScalarBox.php
@@ -16,7 +16,7 @@ namespace Railt\Routing\Store;
 final class ScalarBox extends BaseBox
 {
     /**
-     * Box constructor.
+     * ScalarBox constructor.
      * @param mixed $data
      * @param array $serialized
      */


### PR DESCRIPTION
В компонентах до того как они были в этом репозитории, то же самая проблема встречается. Не знаю,  есть ли автоматический способ выявления и исправления этого.