### PR TITLE
 Correct result determination for stopped FieldResolving event

### DIFF
--- a/src/Adapters/AdapterInterface.php
+++ b/src/Adapters/AdapterInterface.php
@@ -20,6 +20,13 @@ use Railt\SDL\Contracts\Definitions\SchemaDefinition;
 interface AdapterInterface
 {
     /**
+     * AdapterInterface constructor.
+     * @param ContainerInterface $container
+     * @param bool $debug
+     */
+    public function __construct(ContainerInterface $container, bool $debug = false);
+
+    /**
      * @param SchemaDefinition $schema
      * @param RequestInterface $request
      * @return ResponseInterface

--- a/src/Adapters/Webonyx/Builders/FieldBuilder.php
+++ b/src/Adapters/Webonyx/Builders/FieldBuilder.php
@@ -86,7 +86,7 @@ class FieldBuilder extends DependentDefinitionBuilder
             $events->dispatch(FieldResolving::class, $resolving);
 
             if ($resolving->isPropagationStopped()) {
-                return $this->reflection->getTypeDefinition() instanceof ObjectDefinition ? [] : null;
+                return $resolving->getInput()->getFieldDefinition()->isNonNull() ? [] : null;
             }
 
             return $resolving->getResponse();

--- a/src/Adapters/Webonyx/WebonyxInput.php
+++ b/src/Adapters/Webonyx/WebonyxInput.php
@@ -109,7 +109,10 @@ class WebonyxInput implements InputInterface
 
                 case \is_array($sub):
                     yield $relation => $field;
-                    yield from $this->getFlatRelations($sub, $field->getTypeDefinition(), $relation);
+
+                    if ($field->getTypeDefinition() instanceof HasFields) {
+                        yield from $this->getFlatRelations($sub, $field->getTypeDefinition(), $relation);
+                    }
                     break;
 
                 default:

--- a/src/Routing/DefaultResolver.php
+++ b/src/Routing/DefaultResolver.php
@@ -63,8 +63,13 @@ class DefaultResolver
     private function fromParent(InputInterface $input)
     {
         $parent = $input->getParentResponse();
+        $field = $input->getFieldName();
 
-        if ($parent && \array_key_exists($input->getFieldName(), $parent)) {
+        if ($parent && isset($parent[$field])) {
+            if (\is_callable($parent[$field])) {
+                return call_user_func($parent[$field]);
+            }
+
             return $parent[$input->getFieldName()];
         }
 

--- a/src/Routing/DefaultResolver.php
+++ b/src/Routing/DefaultResolver.php
@@ -66,7 +66,7 @@ class DefaultResolver
         $field = $input->getFieldName();
 
         if ($parent && isset($parent[$field])) {
-            if (\is_callable($parent[$field])) {
+            if ($parent[$field] instanceof \Closure) {
                 return call_user_func($parent[$field]);
             }
 

--- a/src/Routing/Store/ObjectBox.php
+++ b/src/Routing/Store/ObjectBox.php
@@ -47,11 +47,11 @@ final class ObjectBox extends BaseBox implements \ArrayAccess
     }
 
     /**
-     * @return array
+     * @return self
      */
-    public function getResponse(): array
+    public function getResponse()
     {
-        return parent::getResponse();
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Steps To Reproduce:

1. Create schema:
```
schema {
    query: Query
}
type Query {
    some: SomeType
}
type SomeType {
    someField: String
}
```
2. Add listener for `FieldResolving::class` event with higher priority than default resolver then call `$event->stopPropagation()`
```
$dispatcher->addListener(FieldResolving::class, function (FieldResolving $event) {
    $event->stopPropagation();
}, 1000);
```
3. Do request:
```
query {
    some {
        someField
    }
}
```

Expected result:
```
{
  "data": {
    "some": null
  }
}
```

Actual result:
```
Argument 2 passed to Railt\\Foundation\\Events\\FieldResolving::__construct() must be an instance of Railt\\Routing\\Store\\ObjectBox or null, array given, called in /var/www/symfony/vendor/railt/railt/src/Adapters/Webonyx/Builders/FieldBuilder.php on line 83
```