### PR TITLE
Correct result determination for stopped FieldResolving event

### DIFF
--- a/src/Adapters/Webonyx/Builders/FieldBuilder.php
+++ b/src/Adapters/Webonyx/Builders/FieldBuilder.php
@@ -86,7 +86,9 @@ class FieldBuilder extends DependentDefinitionBuilder
             $events->dispatch(FieldResolving::class, $resolving);
 
             if ($resolving->isPropagationStopped()) {
-                return $resolving->getInput()->getFieldDefinition()->isNonNull() ? [] : null;
+                $definition = $resolving->getInput()->getFieldDefinition();
+
+                return $definition->isList() && $definition->isNonNull() ? [] : null;
             }
 
             return $resolving->getResponse();


### PR DESCRIPTION
Steps To Reproduce:

1. Create schema:
```
schema {
    query: Query
}
type Query {
    some: SomeType
}
type SomeType {
    someField: String
}
```
2. Add listener for `FieldResolving::class` event with higher priority than default resolver then call `$event->stopPropagation()`
```
$dispatcher->addListener(FieldResolving::class, function (FieldResolving $event) {
    $event->stopPropagation();
}, 1000);
```
3. Do request:
```
query {
    some {
        someField
    }
}
```

Expected result:
```
{
  "data": {
    "some": null
  }
}
```

Actual result:
```
Argument 2 passed to Railt\\Foundation\\Events\\FieldResolving::__construct() must be an instance of Railt\\Routing\\Store\\ObjectBox or null, array given, called in /var/www/symfony/vendor/railt/railt/src/Adapters/Webonyx/Builders/FieldBuilder.php on line 83
```