### PR TITLE
Type "%s" not found and could not be loaded

### DIFF
--- a/src/SDL/Compiler.php
+++ b/src/SDL/Compiler.php
@@ -181,9 +181,11 @@ class Compiler implements CompilerInterface, Configuration
     private function load(Document $document): Document
     {
         foreach ($document->getTypeDefinitions() as $type) {
-            $this->stack->push($type);
-            $this->loader->register($type);
-            $this->stack->pop();
+            if (!$this->loader->has($type->getName())) {
+                $this->stack->push($type);
+                $this->loader->register($type);
+                $this->stack->pop();
+            }
         }
 
         return $document;
@@ -208,6 +210,7 @@ class Compiler implements CompilerInterface, Configuration
     {
         /** @var DocumentBuilder $document */
         $document = $this->storage->remember($readable, $this->onCompile());
+        $this->load($document);
 
         return $document->withCompiler($this);
     }


### PR DESCRIPTION
After compiled types was cached, I get exceptions like:
`Type "CarbonFormat" not found and could not be loaded`

It happens because cached types don't pass into loader. This fix call load method directly and register unloaded types.