### PR TITLE
Remove broken provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,6 @@
     },
     "provide": {
         "graphql/type-system-implementation": "~14.0",
-        "psr/container": "1.0",
         "psr/container-implementation": "1.0"
     },
     "scripts": {


### PR DESCRIPTION
This package does not provide the interfaces of psr/container but only an implementation of the interfaces.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that installing psr/container is not necessary as it is already provided.

Refs composer/composer#9316
